### PR TITLE
Remove preloader and mobile bottom navigation

### DIFF
--- a/about.html
+++ b/about.html
@@ -15,14 +15,6 @@
 </head>
 <body>
     
-    <!-- Preloader -->
-    <div class="preloader">
-        <div class="preloader-content">
-            <img src="./assets/images/PPP logo.jpg" alt="PHIRE'S PRIME PROPERTIES" class="preloader-logo">
-            <div class="preloader-spinner"></div>
-        </div>
-    </div>
-
     <!-- Header -->
     <header class="header">
         <nav class="main-nav">
@@ -67,28 +59,6 @@
             <a href="blog.html">Blog</a>
             <a href="contact.html">Contact</a>
             <a href="contact.html" class="btn btn-primary">Request Site Visit</a>
-        </div>
-    </div>
-
-    <!-- Bottom Card Navigation (Mobile) -->
-    <div class="bottom-nav">
-        <div class="bottom-nav-items">
-            <a href="index.html" class="bottom-nav-item">
-                <i class="ri-home-4-line"></i>
-                <span>Home</span>
-            </a>
-            <a href="projects.html" class="bottom-nav-item">
-                <i class="ri-building-4-line"></i>
-                <span>Projects</span>
-            </a>
-            <a href="offers.html" class="bottom-nav-item">
-                <i class="ri-gift-line"></i>
-                <span>Offers</span>
-            </a>
-            <a href="contact.html" class="bottom-nav-item">
-                <i class="ri-phone-line"></i>
-                <span>Contact</span>
-            </a>
         </div>
     </div>
 

--- a/app.js
+++ b/app.js
@@ -4,16 +4,6 @@
  */
 
 // ========================================
-// PRELOADER
-// ========================================
-window.addEventListener('load', function() {
-    const preloader = document.querySelector('.preloader');
-    setTimeout(() => {
-        preloader.classList.add('hidden');
-    }, 1000);
-});
-
-// ========================================
 // MOBILE NAVIGATION
 // ========================================
 const hamburger = document.querySelector('.hamburger');
@@ -107,7 +97,7 @@ document.querySelectorAll('a[href^="#"]').forEach(anchor => {
         const href = this.getAttribute('href');
         if (href !== '#' && href.length > 1) {
             e.preventDefault();
-            const target = document.querySelector(href');
+            const target = document.querySelector(href);
             if (target) {
                 target.scrollIntoView({
                     behavior: 'smooth',
@@ -923,26 +913,6 @@ function updateActiveNavLink() {
 
 // Update active nav link on page load
 document.addEventListener('DOMContentLoaded', updateActiveNavLink);
-
-// ========================================
-// BOTTOM NAV ACTIVE STATE
-// ========================================
-function updateBottomNavActive() {
-    const currentPage = window.location.pathname.split('/').pop() || 'index.html';
-    const bottomNavItems = document.querySelectorAll('.bottom-nav-item');
-    
-    bottomNavItems.forEach(item => {
-        const href = item.getAttribute('href');
-        if (href === currentPage || (currentPage === '' && href === 'index.html')) {
-            item.classList.add('active');
-        } else {
-            item.classList.remove('active');
-        }
-    });
-}
-
-// Update bottom nav on page load
-document.addEventListener('DOMContentLoaded', updateBottomNavActive);
 
 // ========================================
 // UTILITY FUNCTIONS

--- a/blog-article.html
+++ b/blog-article.html
@@ -10,12 +10,6 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <div class="preloader">
-        <div class="preloader-content">
-            <img src="./assets/images/PPP logo.jpg" alt="PHIRE'S PRIME PROPERTIES" class="preloader-logo">
-            <div class="preloader-spinner"></div>
-        </div>
-    </div>
     <header class="header">
         <nav class="main-nav">
             <div class="container">

--- a/blog.html
+++ b/blog.html
@@ -10,12 +10,6 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <div class="preloader">
-        <div class="preloader-content">
-            <img src="./assets/images/PPP logo.jpg" alt="PHIRE'S PRIME PROPERTIES" class="preloader-logo">
-            <div class="preloader-spinner"></div>
-        </div>
-    </div>
     <header class="header">
         <nav class="main-nav">
             <div class="container">
@@ -46,14 +40,6 @@
             <a href="offers.html">Pre-Launch Offers</a>
             <a href="blog.html">Blog</a>
             <a href="contact.html">Contact</a>
-        </div>
-    </div>
-    <div class="bottom-nav">
-        <div class="bottom-nav-items">
-            <a href="index.html" class="bottom-nav-item"><i class="ri-home-4-line"></i><span>Home</span></a>
-            <a href="projects.html" class="bottom-nav-item"><i class="ri-building-4-line"></i><span>Projects</span></a>
-            <a href="offers.html" class="bottom-nav-item"><i class="ri-gift-line"></i><span>Offers</span></a>
-            <a href="contact.html" class="bottom-nav-item"><i class="ri-phone-line"></i><span>Contact</span></a>
         </div>
     </div>
     <main>

--- a/contact.html
+++ b/contact.html
@@ -15,13 +15,6 @@
 </head>
 <body>
     
-    <div class="preloader">
-        <div class="preloader-content">
-            <img src="./assets/images/PPP logo.jpg" alt="PHIRE'S PRIME PROPERTIES" class="preloader-logo">
-            <div class="preloader-spinner"></div>
-        </div>
-    </div>
-
     <header class="header">
         <nav class="main-nav">
             <div class="container">
@@ -53,15 +46,6 @@
             <a href="offers.html">Pre-Launch Offers</a>
             <a href="blog.html">Blog</a>
             <a href="contact.html">Contact</a>
-        </div>
-    </div>
-
-    <div class="bottom-nav">
-        <div class="bottom-nav-items">
-            <a href="index.html" class="bottom-nav-item"><i class="ri-home-4-line"></i><span>Home</span></a>
-            <a href="projects.html" class="bottom-nav-item"><i class="ri-building-4-line"></i><span>Projects</span></a>
-            <a href="offers.html" class="bottom-nav-item"><i class="ri-gift-line"></i><span>Offers</span></a>
-            <a href="contact.html" class="bottom-nav-item active"><i class="ri-phone-line"></i><span>Contact</span></a>
         </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -23,14 +23,6 @@
 </head>
 <body>
     
-    <!-- Preloader -->
-    <div class="preloader">
-        <div class="preloader-content">
-            <img src="./assets/images/PPP logo.jpg" alt="PHIRE'S PRIME PROPERTIES" class="preloader-logo">
-            <div class="preloader-spinner"></div>
-        </div>
-    </div>
-
     <!-- Header -->
     <header class="header">
         <!-- Main Navigation -->
@@ -78,28 +70,6 @@
             <a href="blog.html">Blog</a>
             <a href="contact.html">Contact</a>
             <a href="contact.html" class="btn btn-primary">Request Site Visit</a>
-        </div>
-    </div>
-
-    <!-- Bottom Card Navigation (Mobile) -->
-    <div class="bottom-nav">
-        <div class="bottom-nav-items">
-            <a href="index.html" class="bottom-nav-item active">
-                <i class="ri-home-4-line"></i>
-                <span>Home</span>
-            </a>
-            <a href="projects.html" class="bottom-nav-item">
-                <i class="ri-building-4-line"></i>
-                <span>Projects</span>
-            </a>
-            <a href="offers.html" class="bottom-nav-item">
-                <i class="ri-gift-line"></i>
-                <span>Offers</span>
-            </a>
-            <a href="contact.html" class="bottom-nav-item">
-                <i class="ri-phone-line"></i>
-                <span>Contact</span>
-            </a>
         </div>
     </div>
 

--- a/offers.html
+++ b/offers.html
@@ -15,14 +15,6 @@
 </head>
 <body>
     
-    <!-- Preloader -->
-    <div class="preloader">
-        <div class="preloader-content">
-            <img src="./assets/images/PPP logo.jpg" alt="PHIRE'S PRIME PROPERTIES" class="preloader-logo">
-            <div class="preloader-spinner"></div>
-        </div>
-    </div>
-
     <!-- Header -->
     <header class="header">
         <nav class="main-nav">
@@ -58,16 +50,6 @@
             <a href="blog.html">Blog</a>
             <a href="contact.html">Contact</a>
             <a href="contact.html" class="btn btn-primary">Request Site Visit</a>
-        </div>
-    </div>
-
-    <!-- Bottom Navigation -->
-    <div class="bottom-nav">
-        <div class="bottom-nav-items">
-            <a href="index.html" class="bottom-nav-item"><i class="ri-home-4-line"></i><span>Home</span></a>
-            <a href="projects.html" class="bottom-nav-item"><i class="ri-building-4-line"></i><span>Projects</span></a>
-            <a href="offers.html" class="bottom-nav-item active"><i class="ri-gift-line"></i><span>Offers</span></a>
-            <a href="contact.html" class="bottom-nav-item"><i class="ri-phone-line"></i><span>Contact</span></a>
         </div>
     </div>
 

--- a/project-detail.html
+++ b/project-detail.html
@@ -10,12 +10,6 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <div class="preloader">
-        <div class="preloader-content">
-            <img src="./assets/images/PPP logo.jpg" alt="PHIRE'S PRIME PROPERTIES" class="preloader-logo">
-            <div class="preloader-spinner"></div>
-        </div>
-    </div>
     <header class="header">
         <nav class="main-nav">
             <div class="container">

--- a/projects.html
+++ b/projects.html
@@ -16,13 +16,6 @@
 <body>
     
     <!-- Preloader -->
-    <div class="preloader">
-        <div class="preloader-content">
-            <img src="./assets/images/PPP logo.jpg" alt="PHIRE'S PRIME PROPERTIES" class="preloader-logo">
-            <div class="preloader-spinner"></div>
-        </div>
-    </div>
-
     <!-- Header -->
     <header class="header">
         <nav class="main-nav">
@@ -67,28 +60,6 @@
             <a href="blog.html">Blog</a>
             <a href="contact.html">Contact</a>
             <a href="contact.html" class="btn btn-primary">Request Site Visit</a>
-        </div>
-    </div>
-
-    <!-- Bottom Card Navigation (Mobile) -->
-    <div class="bottom-nav">
-        <div class="bottom-nav-items">
-            <a href="index.html" class="bottom-nav-item">
-                <i class="ri-home-4-line"></i>
-                <span>Home</span>
-            </a>
-            <a href="projects.html" class="bottom-nav-item active">
-                <i class="ri-building-4-line"></i>
-                <span>Projects</span>
-            </a>
-            <a href="offers.html" class="bottom-nav-item">
-                <i class="ri-gift-line"></i>
-                <span>Offers</span>
-            </a>
-            <a href="contact.html" class="bottom-nav-item">
-                <i class="ri-phone-line"></i>
-                <span>Contact</span>
-            </a>
         </div>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -57,6 +57,7 @@
 html {
   scroll-behavior: smooth;
   font-size: 16px;
+  overflow-x: hidden;
 }
 
 body {

--- a/styles.css
+++ b/styles.css
@@ -428,48 +428,6 @@ p {
   width: 100%;
 }
 
-/* Bottom Card Navigation (Mobile) */
-.bottom-nav {
-  display: block;
-  position: fixed;
-  bottom: 20px;
-  left: 50%;
-  transform: translateX(-50%);
-  background: var(--bg-white);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-lg);
-  padding: 0.625rem 0.75rem;
-  z-index: 900;
-  width: 95%;
-  max-width: 360px;
-}
-
-.bottom-nav-items {
-  display: flex;
-  justify-content: space-around;
-  align-items: center;
-}
-
-.bottom-nav-item {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
-  padding: var(--spacing-xs);
-  color: var(--text-grey);
-  transition: color var(--transition-fast);
-  font-size: 0.7rem;
-}
-
-.bottom-nav-item i {
-  font-size: 1.2rem;
-}
-
-.bottom-nav-item.active,
-.bottom-nav-item:hover {
-  color: var(--primary-red);
-}
-
 /* ========================================
    HERO SECTION (Mobile First)
    ======================================== */
@@ -1445,53 +1403,6 @@ p {
   }
 }
 
-/* ========================================
-   PRELOADER (Mobile First)
-   ======================================== */
-.preloader {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: var(--bg-white);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 9999;
-  transition: opacity 0.5s ease, visibility 0.5s ease;
-}
-
-.preloader.hidden {
-  opacity: 0;
-  visibility: hidden;
-}
-
-.preloader-content {
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-}
-
-.preloader-logo {
-  width: 120px;
-  height: auto;
-  margin-bottom: var(--spacing-md);
-  animation: pulse 1.5s ease-in-out infinite;
-}
-
-.preloader-spinner {
-  width: 40px;
-  height: 40px;
-  border: 3px solid var(--border-light);
-  border-top-color: var(--primary-red);
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-  margin: 0 auto;
-}
-
 @keyframes spin {
   to {
     transform: rotate(360deg);
@@ -1849,20 +1760,6 @@ p {
     justify-content: flex-start;
   }
   
-  /* Bottom nav */
-  .bottom-nav {
-    width: 95%;
-    max-width: 400px;
-  }
-  
-  .bottom-nav-item {
-    font-size: 0.75rem;
-  }
-  
-  .bottom-nav-item i {
-    font-size: 1.3rem;
-  }
-  
   /* WhatsApp FAB */
   .whatsapp-fab {
     width: 60px;
@@ -1912,15 +1809,6 @@ p {
     min-width: 200px;
   }
   
-  /* Preloader */
-  .preloader-logo {
-    width: 140px;
-  }
-  
-  .preloader-spinner {
-    width: 45px;
-    height: 45px;
-  }
 }
 
 /* ========================================
@@ -2126,11 +2014,6 @@ p {
     font-size: 1.2rem;
   }
   
-  /* Hide bottom nav on desktop */
-  .bottom-nav {
-    display: none;
-  }
-  
   /* Scroll button */
   .scroll-to-top {
     bottom: 30px;
@@ -2198,16 +2081,6 @@ p {
     font-size: 1rem;
   }
   
-  /* Preloader */
-  .preloader-logo {
-    width: 150px;
-  }
-  
-  .preloader-spinner {
-    width: 50px;
-    height: 50px;
-    border-width: 4px;
-  }
 }
 
 /* ========================================
@@ -2322,10 +2195,8 @@ p {
    ======================================== */
 @media print {
   .header,
-  .bottom-nav,
   .scroll-to-top,
   .whatsapp-fab,
-  .preloader,
   .hamburger,
   .mobile-menu,
   .mobile-menu-overlay {


### PR DESCRIPTION
## Summary
- remove the preloader overlays and related styles/scripts from all pages
- delete the floating bottom navigation markup and styles across the site
- fix the smooth scrolling selector bug to keep page scripts running and prevent layout issues

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d66246ef0832888bd761e7dcbafb3)